### PR TITLE
Publish axis camera joint states

### DIFF
--- a/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
+++ b/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
@@ -4,12 +4,18 @@
   <arg name="status_topic" default="/axis/state" />
   <arg name="act_ns" default="/axis" />
   <arg name="limits_config" default="$(find axis_ptz_action_server)/config/limits_dome.yaml" />
+  <arg name="camera_name" default="ptz_camera" />
+  <arg name="publish_joint_states" default="true" />
 
   <group ns="$(arg act_ns)">
     <node name="axis_ptz_action_server_node" pkg="axis_ptz_action_server" type="axis_ptz_action_server_node">
       <param name="cmd_topic" value="$(arg cmd_topic)" />
       <param name="status_topic" value="$(arg status_topic)" />
       <param name="act_ns" value="$(arg act_ns)" />
+
+      <param name="publish_joint_states" value="$(arg publish_joint_states)" />
+      <param name="pan_joint" value="$(arg camera_name)_pan_joint" />
+      <param name="tilt_joint" value="$(arg camera_name)_tilt_joint" />
       <rosparam command="load" file="$(arg limits_config)" subst_value="true" />
     </node>
   </group>

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -6,6 +6,7 @@ import actionlib
 from axis_camera.msg import Axis
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzPosition
+from sensor_msgs import JointState
 
 from math import pi
 from math import degrees as rad2deg
@@ -46,6 +47,10 @@ class AxisPtzControlNode:
         self.min_hw_zoom = rospy.get_param("~min_zoom", 1)
         self.max_hw_zoom = rospy.get_param("~max_zoom", 9999)
 
+        self.publish_joint_states = rospy.get_param("~publish_joint_states", True)
+        self.pan_joint = rospy.get_param("~pan_joint", "pan_joint")
+        self.tilt_joint = rospy.get_param("~tilt_joint", "tilt_joint")
+
         self.min_logical_zoom = rospy.get_param("~min_logical_zoom", 1)
         self.max_logical_zoom = rospy.get_param("~max_logical_zoom", 24)
 
@@ -82,6 +87,10 @@ class AxisPtzControlNode:
         self.cmd_pub = rospy.Publisher(self.cmd_topic, Axis, queue_size=1)
         self.status_sub = rospy.Subscriber(self.status_topic, Axis, state_callback, self)
         self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzPosition, queue_size=1)
+
+        if self.publish_joint_states:
+            self.joint_state_pub = rospy.Publisher("/joint_states", JointState, queue_size=1)
+
         self.ptz_srv.start()
 
 
@@ -129,6 +138,15 @@ class AxisPtzControlNode:
         self.ptz_state.tilt = tilt
         self.ptz_state.zoom = zoom
         self.status_pub.publish(self.ptz_state)
+
+        if self.publish_joint_states:
+            js = JointState()
+            js.header.stamp = rospy.Time.now()
+            js.name = [self.pan_joint, self.tilt_joint]
+            js.position = [pan, tilt]
+            js.velocity = [0, 0]
+            js.effort = [0, 0]
+            self.joint_state_pub.publish(js)
 
 
     ## Handles PTZ.action requests

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -6,7 +6,7 @@ import actionlib
 from axis_camera.msg import Axis
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzPosition
-from sensor_msgs import JointState
+from sensor_msgs.msg import JointState
 
 from math import pi
 from math import degrees as rad2deg

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -7,6 +7,7 @@ from axis_camera.msg import Axis
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzPosition
 from sensor_msgs.msg import JointState
+from threading import Thread
 
 from math import pi
 from math import degrees as rad2deg
@@ -90,6 +91,8 @@ class AxisPtzControlNode:
 
         if self.publish_joint_states:
             self.joint_state_pub = rospy.Publisher("/joint_states", JointState, queue_size=1)
+            self.js_thread = Thread(target=self.joint_state_pub_thread)
+            self.js_thread.start()
 
         self.ptz_srv.start()
 
@@ -139,14 +142,18 @@ class AxisPtzControlNode:
         self.ptz_state.zoom = zoom
         self.status_pub.publish(self.ptz_state)
 
-        if self.publish_joint_states:
-            js = JointState()
+    def joint_state_pub_thread(self):
+        js = JointState()
+
+        rate = rospy.Rate(10)
+        while not rospy.is_shutdown():
             js.header.stamp = rospy.Time.now()
             js.name = [self.pan_joint, self.tilt_joint]
-            js.position = [pan, tilt]
+            js.position = [self.ptz_state.pan, self.ptz_state.tilt]
             js.velocity = [0, 0]
             js.effort = [0, 0]
             self.joint_state_pub.publish(js)
+            rate.sleep()
 
 
     ## Handles PTZ.action requests


### PR DESCRIPTION
Add the ability for the Axis PTZ action server to publish to `/joint_states`. This is enabled by default, but can be turned off with an argument or rosparam