### PR TITLE
Major overhaul to add new control modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,19 @@ float32 zoom_remaining
 
 The current state of the camera is reported using the following message format:
 ```
-# PtzPosition.msg
+# PtzState.msg
+int8 MODE_IDLE=0
+int8 MODE_POSITION=1
+int8 MODE_VELOCITY=2
+
+int8 mode
+
 float32 pan
 float32 tilt
 float32 zoom
-
 ```
+
+Regardless of the operating mode, the `pan`, `tilt`, and `zoom` fields report the current positions of the camera.
 
 
 Supported Implementations

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hardware:
   a subset of that range
 - tilt has a maximum allowable range of -pi/2 to +pi/2, though cameras with a restricted field of motion may suport
   a subset of that range
-- positive pan indicates counter-clockwise rotation, negative pan indicates clockwise rotation when the camera is viewed
+- positive pan indicates clockwise rotation, negative pan indicates anticlockwise rotation when the camera is viewed
   from above
 - positive tilt will pitch the camera upwards, negative tilt will pitch the camera downwards
 - zoom is the X-factor of the camera's zoom range. For example, a camera with a 1-24x zoom shall accept zoom values

--- a/axis_ptz_action_server/README.md
+++ b/axis_ptz_action_server/README.md
@@ -11,9 +11,33 @@ Parameters
 -----------
 
 The `axis_ptz_action_server_node` takes the following parameters:
-- `cmd_topic` -- the name of the `Axis.msg` topic provided by the `axis_camera` package to move the unit. Default: `/axis/cmd`
-- `status_topic` -- the name of the `Axis.msg` topic provided by the `flir_ptu` package to report the camera's state. Default: `/axis/state`
-- `act_ns` -- the name of the `Ptz.action` service the node provides. Default: `/ptu_driver/ptz_cmd`
+- `cmd_ns` -- the namespace for the `axis_camera` node's commands. Default: `/axis/cmd`
+- `status_topic` -- the topic for the `axis_camera` node's position status topic. Default: `/axis/state/position`
+- `act_ns` -- the namespace to publish the PTZ actions in. Default: `/axis`.
+- `publish_joint_states`: if true, the action server will publish the pan & tilt angles to `/joint_states`. Default: `true`
+- `pan_joint`: the name of the pan joint in the URDF. Default: `$(camera_name)_pan_joint`
+- `tilt_joint`: the name of the tilt joint in the URDF. Default: `$(camera_name)_tilt_joint`
+
+
+Usage
+------
+
+The `axis_ptz_action_server_node` publishes 3 actionlib servers:
+- `$(act_ns)/move_ptz/position_abs`: send an absolute pan/tilt/zoom position to the camera
+- `$(act_ns)/move_ptz/position_rel`: send a pan/tilt/zoom position relative to the camera's current position
+- `$(act_ns)/move_ptz/velocity`: send velocity control commands to the camera
+
+Pan and tilt values are expressed in radians (or rad/s for velocity control).  Positive pan is to the left relative
+to the camera's base link (anticlockwise), and positive tilt is up.
+
+Position-based zoom levels are in the range `[1, X]` where X is the magnification level of the camera. e.g. a camera with
+a 5x zoom will accept values in the range `[1, 5]` and a 24x zoom will accept values in the range `[1, 24]`.
+
+Velocity-based zoom levels are in the range `[-100, 100]` where the value is the percentage of the camera's maximum
+zoom speed. i.e. `100` is equivalent to zooming in at `100%` of maximum speed and `-25` is equivalent to zooming out
+at `25%` of maximum speed.
+
+These limits can be reconfigured. See `config/limits_dome.yaml` and `config/limits_q62` for examples.
 
 
 Published Topics

--- a/axis_ptz_action_server/config/limits_dome.yaml
+++ b/axis_ptz_action_server/config/limits_dome.yaml
@@ -9,4 +9,4 @@ max_tilt: 1.5707963267948966
 min_zoom: 1
 max_zoom: 9999
 min_logical_zoom: 1
-max_logical_zoom: 24
+max_logical_zoom: 100

--- a/axis_ptz_action_server/config/limits_q62.yaml
+++ b/axis_ptz_action_server/config/limits_q62.yaml
@@ -7,6 +7,6 @@ max_tilt: 1.5707963267948966
 # HW zoom is 1-9999
 min_zoom: 1
 max_zoom: 9999
-# Logcal zoom expressed as 1-100%
+# Logcal zoom expressed as 1-24x
 min_logical_zoom: 1
-max_logical_zoom: 100
+max_logical_zoom: 24

--- a/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
+++ b/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <launch>
-  <arg name="cmd_topic"            default="/axis/cmd" />
-  <arg name="status_topic"         default="/axis/state" />
-  <arg name="act_ns"               default="/axis" />
-  <arg name="limits_config"        default="$(find axis_ptz_action_server)/config/limits.yaml" />
-  <arg name="camera_name"          default="ptz_camera" />
+  <arg name="cmd_ns" default="/axis/cmd" />
+  <arg name="status_topic" default="/axis/state/position" />
+  <arg name="act_ns" default="/axis" />
+  <arg name="limits_config" default="$(find axis_ptz_action_server)/config/limits_dome.yaml" />
+  <arg name="camera_name" default="ptz_camera" />
   <arg name="publish_joint_states" default="true" />
 
   <group ns="$(arg act_ns)">
     <node name="axis_ptz_action_server_node" pkg="axis_ptz_action_server" type="axis_ptz_action_server_node">
-      <param name="cmd_topic"    value="$(arg cmd_topic)" />
+      <param name="cmd_ns" value="$(arg cmd_ns)" />
       <param name="status_topic" value="$(arg status_topic)" />
       <param name="act_ns"       value="$(arg act_ns)" />
 

--- a/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
+++ b/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
@@ -8,7 +8,7 @@
   <arg name="publish_joint_states" default="true" />
 
   <group ns="$(arg act_ns)">
-    <node name="axis_ptz_action_server_node" pkg="axis_ptz_action_server" type="axis_ptz_action_server_node">
+    <node name="ptz_action_server_node" pkg="axis_ptz_action_server" type="axis_ptz_action_server_node">
       <param name="cmd_ns" value="$(arg cmd_ns)" />
       <param name="status_topic" value="$(arg status_topic)" />
       <param name="act_ns"       value="$(arg act_ns)" />

--- a/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
+++ b/axis_ptz_action_server/launch/axis_ptz_action_server_node.launch
@@ -16,6 +16,7 @@
       <param name="publish_joint_states" value="$(arg publish_joint_states)" />
       <param name="pan_joint"  value="$(arg camera_name)_pan_joint" />
       <param name="tilt_joint" value="$(arg camera_name)_tilt_joint" />
+      <param name="camera_base_link" value="$(arg camera_name)_base_link" />
       <rosparam command="load" file="$(arg limits_config)" subst_value="true" />
     </node>
   </group>

--- a/axis_ptz_action_server/package.xml
+++ b/axis_ptz_action_server/package.xml
@@ -9,12 +9,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>ptz_action_server_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+
   <exec_depend>actionlib</exec_depend>
   <exec_depend>axis_camera</exec_depend>
-  <exec_depend>ptz_action_server_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>

--- a/axis_ptz_action_server/package.xml
+++ b/axis_ptz_action_server/package.xml
@@ -9,13 +9,18 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-
-  <depend>ptz_action_server_msgs</depend>
-  <depend>rospy</depend>
-  <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
-
+  <exec_depend>actionlib</exec_depend>
   <exec_depend>axis_camera</exec_depend>
+  <exec_depend>ptz_action_server_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+
+
   <exec_depend>message_runtime</exec_depend>
 
   <export>

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -387,22 +387,15 @@ class AxisPtzControlNode:
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                print(f"{roll} {pitch} {yaw}")
-
-                abs_goal.pan = abs_goal.pan + yaw
-                abs_goal.tilt = abs_goal.tilt + pitch
+                if abs(roll) > deg2rad(5) or abs(pitch) > deg2rad(5):
+                    rospy.logwarn(f"{self.camera_base_link} and {ptz_req.frame_id} are not coplanar; pitch errors may result")
 
                 # clamp the adjusted pan to lie within [-pi, pi]
+                abs_goal.pan = abs_goal.pan + yaw
                 while abs_goal.pan < -math.pi:
                     abs_goal.pan += math.pi
                 while abs_goal.pan < math.pi:
                     abs_goal.pan -= math.pi
-
-                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
-                while abs_goal.tilt < -math.pi/2:
-                    abs_goal.tilt += math.pi
-                while abs_goal.tilt < math.pi/2:
-                    abs_goal.tilt -= math.pi
 
             except Exception as err:
                 rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -3,7 +3,7 @@
 import rospy
 import actionlib
 
-from axis_msgs.msg import Axis, Ptz
+from axis_msgs.msg import Ptz
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
@@ -33,13 +33,16 @@ class AxisPtzControlNode:
     """Provides a PTZ.action compatible interface for sending pan-tilt-zoom positions to the axis_camera driver
     """
 
-    ## How long before we consider the Axis.msg sent on the status topic to be stale?
+    ## How long before we consider the last message sent on the status topic to be stale?
     STATE_TIMEOUT = rospy.Duration(10)
 
     def __init__(self):
-        self.cmd_pos_topic = rospy.get_param('~cmd_pos_topic', '/axis/cmd/position')
-        self.cmd_vel_topic = rospy.get_param('~cmd_vel_topic', '/axis/cmd/velocity')
-        self.status_topic = rospy.get_param('~status_topic', '/axis/state')
+        self.cmd_ns = rospy.get_param('~cmd_ns', '/axis/cmd')
+        if self.cmd_ns[0] != '/':
+            self.cmd_ns = f"/{self.cmd_ns}"
+        self.cmd_pos_topic = f'{self.cmd_ns}/position'
+        self.cmd_vel_topic = f'{self.cmd_ns}/velocity'
+        self.status_topic = rospy.get_param('~status_topic', '/axis/state/position')
         self.act_ns = rospy.get_param('~act_ns', '/axis')
         self.invert_tilt = rospy.get_param('~invert_tilt', False)
         self.invert_pan = rospy.get_param('~invert_pan', False)
@@ -75,26 +78,25 @@ class AxisPtzControlNode:
 
         # The current logical PTZ state
         self.ptz_state = PtzState()
-        self.PtzState.zoom = 1
+        self.ptz_state.zoom = 1
 
         # is the camera currently moving?
         self.is_moving = False
         self.is_moving_lock = Lock()
 
-        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/position', PtzAction, self.ptz_actionHandler, False)
-        self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/velocity', PtzAction, self.vel_actionHandler, False)
+        self.ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
+        self.ptz_rel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
+        self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/velocity', PtzAction, self.vel_actionHandler, False)
 
         self.last_state_at = rospy.Time.now()
-
         self.last_command_at = rospy.Time.now()
-
 
     def start(self):
         """Starts the subscribers, publishers, and service handlers
         """
         self.cmd_pos_pub = rospy.Publisher(self.cmd_pos_topic, Ptz, queue_size=1)
         self.cmd_vel_pub = rospy.Publisher(self.cmd_vel_topic, Ptz, queue_size=1)
-        self.status_sub = rospy.Subscriber(self.status_topic, Axis, state_callback, self)
+        self.status_sub = rospy.Subscriber(self.status_topic, Ptz, self.state_callback)
         self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzState, queue_size=1)
 
         if self.publish_joint_states:
@@ -102,28 +104,27 @@ class AxisPtzControlNode:
             self.js_thread = Thread(target=self.joint_state_pub_thread)
             self.js_thread.start()
 
-        self.ptz_srv.start()
-
+        self.ptz_abs_srv.start()
+        self.ptz_rel_srv.start()
+        self.vel_srv.start()
 
     def state_callback(self, data):
-        """Monitors /axis/state to determine if the pan and tilt joints have reached their goal positions yet
+        """Monitors the position of the camera to determine if the pan and tilt joints have reached their
+        goal positions yet
 
         Also saves the current state to self.last_axis_state
 
-        @param data  The Axis.msg information received on the topic
+        @param data  The Ptz.msg information received on the topic
         """
         pan = deg2rad(data.pan)
         tilt = deg2rad(data.tilt)
         zoom = linear_rescale(data.zoom, self.min_hw_zoom, self.max_hw_zoom, self.min_logical_zoom, self.max_logical_zoom)
 
-        # by default the underlying Axis driver uses + as right, but we use
-        # + as left
-        if not self.invert_pan:
-            pan = -pan
-
-        # invert the tilt if necessary
+        # invert pan & tilt if necessary
         if self.invert_tilt:
             tilt = -tilt
+        if self.invert_pan:
+            pan = -pan
 
         # distance remaining to goal state
         pan_remaining = abs(pan - self.goal_pan)
@@ -143,18 +144,7 @@ class AxisPtzControlNode:
             # check if we've reached the goal
             if pan_remaining <= self.position_tolerance and tilt_remaining <= self.position_tolerance and zoom_remaining <= self.zoom_tolerance:
                 rospy.loginfo("PTZ reached goal!")
-                self.set_is_moving(False)
-            elif dpan <= POINT_ONE_DEGREE and dtilt <= POINT_ONE_DEGREE and dzoom <= 1:
-                rospy.logwarn("PTZ stopped moving!")
-                self.set_is_moving(False)
-            elif self.last_axis_state.pan == data.pan and \
-                 self.last_axis_state.tilt == data.tilt and \
-                 self.last_axis_state.zoom == data.zoom and \
-                 (rospy.Time.now() - self.last_command_at) > rospy.Duration(5):
-                # check that we're actually moving towards the goal
-                # if we aren't, re-send the command
-                rospy.logwarn("Axis camera doesn't appear to be moving; re-sending last command")
-                self.command_axis()
+                self.is_moving = False
 
         self.last_axis_state = data
         self.last_state_at = rospy.Time.now()
@@ -164,7 +154,6 @@ class AxisPtzControlNode:
         self.ptz_state.tilt = tilt
         self.ptz_state.zoom = zoom
         self.status_pub.publish(self.ptz_state)
-
 
     def joint_state_pub_thread(self):
         js = JointState()
@@ -179,8 +168,7 @@ class AxisPtzControlNode:
             self.joint_state_pub.publish(js)
             rate.sleep()
 
-
-    def ptz_actionHandler(self, ptz_req):
+    def ptz_abs_actionHandler(self, ptz_req):
         """Handles PTZ.action requests to set absolute pan/tilt/zoom positions
 
         Converts the PTZ goal into an Axis.msg we write to the axis_camera driver
@@ -193,14 +181,14 @@ class AxisPtzControlNode:
             rospy.logwarn('Still waiting for initial state from the camera. Cannot move yet')
             ptz_resp = PtzResult()
             ptz_resp.success = False
-            self.ptz_srv.set_aborted(ptz_resp, 'Still waiting for initial state from the camera. Cannot move yet')
+            self.ptz_abs_srv.set_aborted(ptz_resp, 'Still waiting for initial state from the camera. Cannot move yet')
 
         elif rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
             # We haven't heard from the camera in a while; block until the camera updates its status again
             rospy.logwarn("Status of Axis camera is stale. Waiting for the camera to come back online")
             ptz_resp = PtzResult()
             ptz_resp.success = False
-            self.ptz_srv.set_aborted(ptz_resp, "Status of Axis camera is stale; waiting for camera to publish its state again")
+            self.ptz_abs_srv.set_aborted(ptz_resp, "Status of Axis camera is stale; waiting for camera to publish its state again")
 
         else:
             if self.ptz_state.mode == PtzState.MODE_VELOCITY:
@@ -219,13 +207,13 @@ class AxisPtzControlNode:
             ptz.zoom = self.goal_zoom
             self.cmd_vel_pub.publish(cmd)
             self.last_command_at = rospy.Time.now()
-            self.ptz_state = PtzState.MODE_POSITION
+            self.ptz_state.mode = PtzState.MODE_POSITION
 
             # sleep until joint_states reports that the pan and tilt joints have reached the desired position OR
             # have stopped moving
             rate = rospy.Rate(2)
             timed_out = False
-            while self.is_moving and not self.ptz_srv.is_preempt_requested() and not timed_out:
+            while self.is_moving and not self.ptz_abs_srv.is_preempt_requested() and not timed_out:
                 feedback = PtzFeedback()
                 feedback.zoom_remaining = self.goal_zoom - self.ptz_state.zoom
                 feedback.pan_remaining = self.goal_pan - self.ptz_state.pan
@@ -238,23 +226,50 @@ class AxisPtzControlNode:
                     rospy.logdebug(f"PTZ is still moving ({feedback.pan_remaining}, {feedback.tilt_remaining}, {feedback.zoom_remaining}) to go")
                     rate.sleep()
 
-            if self.ptz_srv.is_preempt_requested():
+            if self.ptz_abs_srv.is_preempt_requested():
                 rospy.logwarn("PTZ action preempted")
-                self.ptz_srv.set_preempted()
+                self.is_moving = False
+                self.ptz_abs_srv.set_preempted()
             elif timed_out:
                 rospy.logwarn("Timed out waiting for axis camera state")
                 self.is_moving = False
                 ptz_resp = PtzResult()
                 ptz_resp.success = False
-                self.ptz_state = PtzState.MODE_IDLE
-                self.ptz_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
+                self.ptz_state.mode = PtzState.MODE_IDLE
+                self.ptz_abs_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
             else:
                 rospy.logdebug("PTZ action completed successfully")
                 ptz_resp = PtzResult()
                 ptz_resp.success = True
-                self.ptz_state = PtzState.MODE_IDLE
-                self.ptz_srv.set_succeeded(ptz_resp)
+                self.ptz_state.mode = PtzState.MODE_IDLE
+                self.ptz_abs_srv.set_succeeded(ptz_resp)
 
+    def ptz_rel_actionHandler(self, ptz_req):
+        """Handler for moving the camera to a relative pan/tilt/zoom from current
+
+        Converts the relative pan/tilt/zoom to absolute positions and uses the position_abs action
+        """
+        abs_goal = PtzGoal(self.current_pan + ptz_req.pan,
+                           self.current_tilt + ptz_req.tilt,
+                           self.current_zoom + ptz_req.zoom
+        )
+
+        ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+        ptz_client.wait_for_server()
+
+        def done_cb(state, result):
+            if state == actionlib.GoalStatus.SUCCEEDED:
+                self.ptz_rel_srv.set_succeeded(result)
+            elif state == actionlib.GoalStatus.PREEMPTED:
+                self.ptz_rel_srv.set_preempted()
+            else:
+                self.ptz_rel_srv.set_aborted(result)
+
+        ptz_client.send_goal(abs_goal,
+            feedback_cb = lambda fb: self.ptz_rel_srv.publish_feedback(fb),
+            done_cb = done_cb
+        )
+        ptz_client.wait_for_result()
 
     def vel_actionHandler(self, ptz_req):
         """Handles PTZ.action requests for velocity control
@@ -282,48 +297,59 @@ class AxisPtzControlNode:
             ptz_resp = PtzResult()
             ptz_resp.success = False
             self.vel_srv.set_aborted(ptz_resp, "Camera is moving under position control")
+        elif self.ptz_state.mode == PtzState.MODE_VELOCITY and ptz_req.pan == 0 and ptz_req.tilt == 0 and ptz_req.zoom == 0:
+            rospy.loginfo("Stopping camera")
+            self.vel_srv.set_preempted()
         else:
             # The camera is alive and ready to move
             cmd = Ptz()
             cmd.pan = ptz_req.pan
             cmd.tilt = ptz_req.tilt
             cmd.zoom = ptz_req.zoom
-            self.is_moving = True
             self.cmd_vel_pub.publish(cmd)
-            self.ptz_state.mode = PtzState.MODE_VELOCITY
+            if cmd.pan != 0 or cmd.tilt != 0 or cmd.zoom != 0:
+                self.is_moving = True
+                self.ptz_state.mode = PtzState.MODE_VELOCITY
 
-            rate = rospy.Rate(2)
-            timed_out = False
-            while self.is_moving and not self.vel_srv.is_preempt_requested() and not timed_out:
-                feedback = PtzFeedback()
-                feedback.zoom_remaining = 0
-                feedback.pan_remaining = 0
-                feedback.tilt_remaining = 0
-                self.vel_srv.publish_feedback(feedback)
+                rate = rospy.Rate(2)
+                timed_out = False
+                while self.is_moving and not self.vel_srv.is_preempt_requested() and not timed_out:
+                    feedback = PtzFeedback()
+                    feedback.zoom_remaining = 0
+                    feedback.pan_remaining = 0
+                    feedback.tilt_remaining = 0
+                    self.vel_srv.publish_feedback(feedback)
 
-                if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
-                    timed_out = True
+                    if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
+                        timed_out = True
+                    else:
+                        rospy.logdebug(f"PTZ is still moving ({feedback.pan_remaining}, {feedback.tilt_remaining}, {feedback.zoom_remaining}) to go")
+                        rate.sleep()
+
+                if self.vel_srv.is_preempt_requested():
+                    rospy.logwarn("Velocity action preempted")
+                    self.is_moving = False
+                    self.vel_srv.set_preempted()
+                elif timed_out:
+                    rospy.logwarn("Timed out waiting for axis camera state")
+                    self.is_moving = False
+                    ptz_resp = PtzResult()
+                    ptz_resp.success = False
+                    self.vel_state = PtzState.MODE_IDLE
+                    self.vel_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
                 else:
-                    rospy.logdebug(f"PTZ is still moving ({feedback.pan_remaining}, {feedback.tilt_remaining}, {feedback.zoom_remaining}) to go")
-                    rate.sleep()
-
-            if self.vel_srv.is_preempt_requested():
-                rospy.logwarn("Velocity action preempted")
-                self.is_moving = False
-                self.vel_srv.set_preempted()
-            elif timed_out:
-                rospy.logwarn("Timed out waiting for axis camera state")
-                self.is_moving = False
-                ptz_resp = PtzResult()
-                ptz_resp.success = False
-                self.vel_state = PtzState.MODE_IDLE
-                self.vel_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
+                    rospy.logdebug("Velocity action completed successfully")
+                    ptz_resp = PtzResult()
+                    ptz_resp.success = True
+                    self.ptz_state.mode = PtzState.MODE_IDLE
+                    self.vel_srv.set_succeeded(ptz_resp)
             else:
-                rospy.logdebug("PTZ action completed successfully")
+                rospy.logdebug("Velocity action completed successfully")
                 ptz_resp = PtzResult()
                 ptz_resp.success = True
-                self.ptz_state = PtzState.MODE_IDLE
-                self.ptz_srv.set_succeeded(ptz_resp)
+                self.is_moving = False
+                self.ptz_state.mode = PtzState.MODE_IDLE
+                self.vel_srv.set_succeeded(ptz_resp)
 
 
 def main():

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -6,8 +6,10 @@ import rospy
 import tf2_ros
 import tf2_geometry_msgs
 import tf.transformations
+import uuid
 
 from axis_msgs.msg import Ptz
+from geometry_msgs.msg import TransformStamped
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
@@ -100,6 +102,9 @@ class AxisPtzControlNode:
 
         self.last_state_at = rospy.Time.now()
         self.last_command_at = rospy.Time.now()
+
+        self.tf_broadcaster = tf2_ros.StaticTransformBroadcaster()
+        self.camera_vector_frame = f"camera_vector_frame_{str(uuid.uuid1()).replace('-', '_')}"
 
     def start(self):
         """Starts the subscribers, publishers, and service handlers
@@ -380,25 +385,39 @@ class AxisPtzControlNode:
 
         if ptz_req.frame_id:
             try:
+                # add a temporary frame to represent the desired camera vector
+                camera_vector_q = tf.transformations.quaternion_from_euler(0, -ptz_req.tilt, ptz_req.pan)
+                static_tf = TransformStamped()
+                static_tf.header.stamp = rospy.Time.now()
+                static_tf.header.frame_id = ptz_req.frame_id
+                static_tf.child_frame_id = self.camera_vector_frame
+                static_tf.transform.rotation.x = camera_vector_q[0]
+                static_tf.transform.rotation.y = camera_vector_q[1]
+                static_tf.transform.rotation.z = camera_vector_q[2]
+                static_tf.transform.rotation.w = camera_vector_q[3]
+                self.tf_broadcaster.sendTransform(static_tf)
+
                 # The the RPY transformation between the camera base link & the reference frame
                 tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
                 tf_listener = tf2_ros.TransformListener(tf_buffer)
-                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, self.camera_vector_frame, rospy.Time(0), rospy.Duration(5.0))
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                if abs(roll) > deg2rad(5) or abs(pitch) > deg2rad(5):
-                    rospy.logwarn(f"{self.camera_base_link} and {ptz_req.frame_id} are not coplanar; pitch errors may result")
+                abs_goal.pan = yaw
+                abs_goal.tilt = -pitch
 
                 # clamp the adjusted pan to lie within [-pi, pi]
-                abs_goal.pan = abs_goal.pan + yaw
                 while abs_goal.pan < -math.pi:
                     abs_goal.pan += math.pi
-                while abs_goal.pan < math.pi:
+                while abs_goal.pan > math.pi:
                     abs_goal.pan -= math.pi
 
-            except Exception as err:
-                rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")
+                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+                while abs_goal.tilt < -math.pi/2:
+                    abs_goal.tilt += math.pi
+                while abs_goal.tilt > math.pi/2:
+                    abs_goal.tilt -= math.pi
 
         ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
         ptz_client.wait_for_server()

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -141,10 +141,15 @@ class AxisPtzControlNode:
         POINT_ONE_DEGREE = deg2rad(0.1)
 
         if self.is_moving:
-            # check if we've reached the goal
-            if pan_remaining <= self.position_tolerance and tilt_remaining <= self.position_tolerance and zoom_remaining <= self.zoom_tolerance:
-                rospy.loginfo("PTZ reached goal!")
-                self.is_moving = False
+            if self.ptz_state.mode == PtzState.MODE_POSITION:
+                # check if we've reached the goal
+                if dpan <= self.position_tolerance and dtilt <= self.position_tolerance and dzoom <= self.zoom_tolerance:
+                    rospy.loginfo("PTZ reached goal!")
+                    self.is_moving = False
+            elif self.ptz_state.mode == PtzState.MODE_VELOCITY:
+                if dpan == 0 and dtilt == 0 and dzoom == 0:
+                    rospy.loginfo("PTZ reached end-of-travel!")
+                    self.is_moving = False
 
         self.last_axis_state = data
         self.last_state_at = rospy.Time.now()
@@ -315,9 +320,9 @@ class AxisPtzControlNode:
                 timed_out = False
                 while self.is_moving and not self.vel_srv.is_preempt_requested() and not timed_out:
                     feedback = PtzFeedback()
-                    feedback.zoom_remaining = 0
-                    feedback.pan_remaining = 0
-                    feedback.tilt_remaining = 0
+                    feedback.zoom_remaining = math.copysign(1, req.zoom)
+                    feedback.pan_remaining = math.copysign(1, req.pan)
+                    feedback.tilt_remaining = math.copysign(1, req.tilt)
                     self.vel_srv.publish_feedback(feedback)
 
                     if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -11,6 +11,7 @@ import uuid
 from axis_msgs.msg import Ptz
 from geometry_msgs.msg import TransformStamped
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzFrameAction, PtzFrameFeedback, PtzFrameGoal, PtzFrameResult
 from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
@@ -99,6 +100,7 @@ class AxisPtzControlNode:
         self.ptz_rel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
         self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/velocity', PtzAction, self.vel_actionHandler, False)
         self.tf_ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs_tf', PtzRelTo, self.tf_ptz_abs_actionHandler, False)
+        self.frame_ptz_srv = actionlib.SimpleActionServer('move_ptz/frame', PtzFrameAction, self.frame_ptz_actionHandler, False)
 
         self.last_state_at = rospy.Time.now()
         self.last_command_at = rospy.Time.now()
@@ -123,6 +125,7 @@ class AxisPtzControlNode:
         self.ptz_rel_srv.start()
         self.vel_srv.start()
         self.tf_ptz_abs_srv.start()
+        self.frame_ptz_srv.start()
 
     def state_callback(self, data):
         """Monitors the position of the camera to determine if the pan and tilt joints have reached their
@@ -441,6 +444,70 @@ class AxisPtzControlNode:
             done_cb = done_cb
         )
         ptz_client.wait_for_result()
+
+    def frame_ptz_actionHandler(self, ptz_req):
+        """Pan & tilt the camera to point to a specific frame in the TF tree
+        """
+        abs_goal = PtzGoal()
+        abs_goal.zoom = ptz_req.zoom
+
+        try:
+            # The the transformation between the camera base link & the reference frame
+            tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
+            tf_listener = tf2_ros.TransformListener(tf_buffer)
+            tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+
+            # we want to get the pan & tilt needed to point at the frame
+            r = math.sqrt(tf_stamped.transform.translation.x**2 + tf_stamped.transform.translation.y**2 + tf_stamped.transform.translation.z**2)
+            yaw = math.atan2(tf_stamped.transform.translation.y, tf_stamped.transform.translation.x)
+            pitch = -math.asin(tf_stamped.transform.translation.z/r)
+
+            # yaw & pitch are right-handed, but pan & tilt are left-handed, so invert them
+            abs_goal.pan = -yaw
+            abs_goal.tilt = -pitch
+
+            # clamp the adjusted pan to lie within [-pi, pi]
+            while abs_goal.pan < -math.pi:
+                abs_goal.pan += math.pi
+            while abs_goal.pan > math.pi:
+                abs_goal.pan -= math.pi
+
+            # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+            while abs_goal.tilt < -math.pi/2:
+                abs_goal.tilt += math.pi
+            while abs_goal.tilt > math.pi/2:
+                abs_goal.tilt -= math.pi
+
+            print(abs_goal)
+
+            ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+            ptz_client.wait_for_server()
+
+            def done_cb(state, result):
+                tf_result = PtzFrameResult(result.success)
+                if state == actionlib.GoalStatus.SUCCEEDED:
+                    self.frame_ptz_srv.set_succeeded(tf_result)
+                elif state == actionlib.GoalStatus.PREEMPTED:
+                    self.frame_ptz_srv.set_preempted()
+                else:
+                    self.frame_ptz_srv.set_aborted(tf_result)
+
+            def feedback_cb(fb):
+                tf_fb = PtzFrameFeedback(fb.pan_remaining, fb.tilt_remaining, fb.zoom_remaining)
+                self.frame_ptz_srv.publish_feedback(tf_fb)
+
+            ptz_client.send_goal(abs_goal,
+                feedback_cb = feedback_cb,
+                done_cb = done_cb
+            )
+            ptz_client.wait_for_result()
+
+        except Exception as err:
+            err_msg = f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}"
+            rospy.logerr(err_msg)
+            result = PtzFrameResult()
+            result.success = False
+            self.frame_ptz_srv.set_aborted(result, err_msg)
 
 
 def main():

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -99,7 +99,7 @@ class AxisPtzControlNode:
         self.ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
         self.ptz_rel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
         self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/velocity', PtzAction, self.vel_actionHandler, False)
-        self.tf_ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs_tf', PtzRelTo, self.tf_ptz_abs_actionHandler, False)
+        self.tf_ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs_tf', PtzRelToAction, self.tf_ptz_abs_actionHandler, False)
         self.frame_ptz_srv = actionlib.SimpleActionServer('move_ptz/frame', PtzFrameAction, self.frame_ptz_actionHandler, False)
 
         self.last_state_at = rospy.Time.now()
@@ -422,6 +422,9 @@ class AxisPtzControlNode:
                     abs_goal.tilt += math.pi
                 while abs_goal.tilt > math.pi/2:
                     abs_goal.tilt -= math.pi
+
+            except Exception as err:
+                rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")
 
         ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
         ptz_client.wait_for_server()

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-import rospy
 import actionlib
+import math
+import rospy
 
 from axis_msgs.msg import Ptz
-from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
 from threading import Lock, Thread
@@ -78,6 +79,8 @@ class AxisPtzControlNode:
 
         # The current logical PTZ state
         self.ptz_state = PtzState()
+        self.ptz_state.pan = 0
+        self.ptz_state.tilt = 0
         self.ptz_state.zoom = 1
 
         # is the camera currently moving?
@@ -116,8 +119,8 @@ class AxisPtzControlNode:
 
         @param data  The Ptz.msg information received on the topic
         """
-        pan = deg2rad(data.pan)
-        tilt = deg2rad(data.tilt)
+        pan = data.pan
+        tilt = data.tilt
         zoom = linear_rescale(data.zoom, self.min_hw_zoom, self.max_hw_zoom, self.min_logical_zoom, self.max_logical_zoom)
 
         # invert pan & tilt if necessary
@@ -126,27 +129,23 @@ class AxisPtzControlNode:
         if self.invert_pan:
             pan = -pan
 
-        # distance remaining to goal state
-        pan_remaining = abs(pan - self.goal_pan)
-        tilt_remaining = abs(tilt - self.goal_tilt)
-        zoom_remaining = abs(zoom - self.goal_zoom)
-
-        # delta between now and the previous reading
-        dpan = abs(pan - self.ptz_state.pan)
-        dtilt = abs(tilt - self.ptz_state.tilt)
-        dzoom = abs(zoom - self.ptz_state.zoom)
-
-        # assume we've stopped if the pan and tilt speeds are both less that 0.1 deg/s
-        # there aren't many use-cases where movement that slow would be necessary
-        POINT_ONE_DEGREE = deg2rad(0.1)
-
         if self.is_moving:
             if self.ptz_state.mode == PtzState.MODE_POSITION:
+                pan_remaining = abs(self.goal_pan - pan)
+                tilt_remaining = abs(self.goal_tilt - tilt)
+                zoom_remaining = abs(self.goal_zoom - zoom)
+
                 # check if we've reached the goal
-                if dpan <= self.position_tolerance and dtilt <= self.position_tolerance and dzoom <= self.zoom_tolerance:
+                if pan_remaining <= self.position_tolerance and \
+                   tilt_remaining <= self.position_tolerance and \
+                   zoom_remaining <= self.zoom_tolerance:
                     rospy.loginfo("PTZ reached goal!")
                     self.is_moving = False
             elif self.ptz_state.mode == PtzState.MODE_VELOCITY:
+                dpan = self.last_axis_state.pan - data.pan
+                dtilt = self.last_axis_state.tilt - data.tilt
+                dzoom = self.last_axis_state.zoom - data.zoom
+
                 if dpan == 0 and dtilt == 0 and dzoom == 0:
                     rospy.loginfo("PTZ reached end-of-travel!")
                     self.is_moving = False
@@ -207,10 +206,10 @@ class AxisPtzControlNode:
             # send the command to the camera
             self.is_moving = True
             cmd = Ptz()
-            ptz.pan = self.goal_pan
-            ptz.tilt = self.goal_tilt
-            ptz.zoom = self.goal_zoom
-            self.cmd_vel_pub.publish(cmd)
+            cmd.pan = self.goal_pan
+            cmd.tilt = self.goal_tilt
+            cmd.zoom = self.goal_zoom
+            self.cmd_pos_pub.publish(cmd)
             self.last_command_at = rospy.Time.now()
             self.ptz_state.mode = PtzState.MODE_POSITION
 
@@ -223,7 +222,7 @@ class AxisPtzControlNode:
                 feedback.zoom_remaining = self.goal_zoom - self.ptz_state.zoom
                 feedback.pan_remaining = self.goal_pan - self.ptz_state.pan
                 feedback.tilt_remaining = self.goal_tilt - self.ptz_state.tilt
-                self.ptz_srv.publish_feedback(feedback)
+                self.ptz_abs_srv.publish_feedback(feedback)
 
                 if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
                     timed_out = True
@@ -254,9 +253,9 @@ class AxisPtzControlNode:
 
         Converts the relative pan/tilt/zoom to absolute positions and uses the position_abs action
         """
-        abs_goal = PtzGoal(self.current_pan + ptz_req.pan,
-                           self.current_tilt + ptz_req.tilt,
-                           self.current_zoom + ptz_req.zoom
+        abs_goal = PtzGoal(self.ptz_state.pan + ptz_req.pan,
+                           self.ptz_state.tilt + ptz_req.tilt,
+                           self.ptz_state.zoom + ptz_req.zoom
         )
 
         ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
@@ -270,8 +269,11 @@ class AxisPtzControlNode:
             else:
                 self.ptz_rel_srv.set_aborted(result)
 
+        def feedback_cb(fb):
+            self.ptz_rel_srv.publish_feedback(fb)
+
         ptz_client.send_goal(abs_goal,
-            feedback_cb = lambda fb: self.ptz_rel_srv.publish_feedback(fb),
+            feedback_cb = feedback_cb,
             done_cb = done_cb
         )
         ptz_client.wait_for_result()
@@ -320,9 +322,9 @@ class AxisPtzControlNode:
                 timed_out = False
                 while self.is_moving and not self.vel_srv.is_preempt_requested() and not timed_out:
                     feedback = PtzFeedback()
-                    feedback.zoom_remaining = math.copysign(1, req.zoom)
-                    feedback.pan_remaining = math.copysign(1, req.pan)
-                    feedback.tilt_remaining = math.copysign(1, req.tilt)
+                    feedback.zoom_remaining = math.copysign(1, ptz_req.zoom)
+                    feedback.pan_remaining = math.copysign(1, ptz_req.pan)
+                    feedback.tilt_remaining = math.copysign(1, ptz_req.tilt)
                     self.vel_srv.publish_feedback(feedback)
 
                     if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -404,7 +404,8 @@ class AxisPtzControlNode:
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                abs_goal.pan = yaw
+                # yaw & pitch are right-handed, but pan & tilt are left-handed, so invert them
+                abs_goal.pan = -yaw
                 abs_goal.tilt = -pitch
 
                 # clamp the adjusted pan to lie within [-pi, pi]

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -3,9 +3,9 @@
 import rospy
 import actionlib
 
-from axis_camera.msg import Axis
+from axis_msgs.msg import Axis, Ptz
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
-from ptz_action_server_msgs.msg import PtzPosition
+from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
 from threading import Lock, Thread
 
@@ -29,13 +29,16 @@ def clamp(x, min, max, metavar):
     else:
         return x
 
-## Provides a PTZ.action compatible interface for sending pan-tilt-zoom positions to the axis_camera driver
 class AxisPtzControlNode:
+    """Provides a PTZ.action compatible interface for sending pan-tilt-zoom positions to the axis_camera driver
+    """
+
     ## How long before we consider the Axis.msg sent on the status topic to be stale?
     STATE_TIMEOUT = rospy.Duration(10)
 
     def __init__(self):
-        self.cmd_topic = rospy.get_param('~cmd_topic', '/axis/cmd')
+        self.cmd_pos_topic = rospy.get_param('~cmd_pos_topic', '/axis/cmd/position')
+        self.cmd_vel_topic = rospy.get_param('~cmd_vel_topic', '/axis/cmd/velocity')
         self.status_topic = rospy.get_param('~status_topic', '/axis/state')
         self.act_ns = rospy.get_param('~act_ns', '/axis')
         self.invert_tilt = rospy.get_param('~invert_tilt', False)
@@ -71,24 +74,28 @@ class AxisPtzControlNode:
         self.last_axis_state = None
 
         # The current logical PTZ state
-        self.ptz_state = PtzPosition(0, 0, 1)
+        self.ptz_state = PtzState()
+        self.PtzState.zoom = 1
 
         # is the camera currently moving?
         self.is_moving = False
         self.is_moving_lock = Lock()
 
-        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz', PtzAction, self.ptz_actionHandler, False)
+        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/position', PtzAction, self.ptz_actionHandler, False)
+        self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/velocity', PtzAction, self.vel_actionHandler, False)
 
         self.last_state_at = rospy.Time.now()
 
         self.last_command_at = rospy.Time.now()
 
 
-    ## Starts the subscribers, publishers, and service handlers
     def start(self):
-        self.cmd_pub = rospy.Publisher(self.cmd_topic, Axis, queue_size=1)
+        """Starts the subscribers, publishers, and service handlers
+        """
+        self.cmd_pos_pub = rospy.Publisher(self.cmd_pos_topic, Ptz, queue_size=1)
+        self.cmd_vel_pub = rospy.Publisher(self.cmd_vel_topic, Ptz, queue_size=1)
         self.status_sub = rospy.Subscriber(self.status_topic, Axis, state_callback, self)
-        self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzPosition, queue_size=1)
+        self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzState, queue_size=1)
 
         if self.publish_joint_states:
             self.joint_state_pub = rospy.Publisher("/joint_states", JointState, queue_size=1)
@@ -98,11 +105,13 @@ class AxisPtzControlNode:
         self.ptz_srv.start()
 
 
-    ## Monitors /axis/state to determine if the pan and tilt joints have reached their goal positions yet
-    #  Also saves the current state to self.last_axis_state
-    #
-    # \param data  The Axis.msg information received on the topic
     def state_callback(self, data):
+        """Monitors /axis/state to determine if the pan and tilt joints have reached their goal positions yet
+
+        Also saves the current state to self.last_axis_state
+
+        @param data  The Axis.msg information received on the topic
+        """
         pan = deg2rad(data.pan)
         tilt = deg2rad(data.tilt)
         zoom = linear_rescale(data.zoom, self.min_hw_zoom, self.max_hw_zoom, self.min_logical_zoom, self.max_logical_zoom)
@@ -156,6 +165,7 @@ class AxisPtzControlNode:
         self.ptz_state.zoom = zoom
         self.status_pub.publish(self.ptz_state)
 
+
     def joint_state_pub_thread(self):
         js = JointState()
 
@@ -170,12 +180,14 @@ class AxisPtzControlNode:
             rate.sleep()
 
 
-    ## Handles PTZ.action requests
-    #  Converts the PTZ goal into an Axis.msg we write to the axis_camera driver
-    #  and then wait until the feedback topic reports that the PTU has finished moving
-    #
-    #  \param ptz_req  The PtzGoal object to process
     def ptz_actionHandler(self, ptz_req):
+        """Handles PTZ.action requests to set absolute pan/tilt/zoom positions
+
+        Converts the PTZ goal into an Axis.msg we write to the axis_camera driver
+        and then wait until the feedback topic reports that the PTU has finished moving
+
+        @param ptz_req  The PtzGoal object to process
+        """
         if self.last_axis_state == None:
             # We have never contacted the camera; block until we hear _something_
             rospy.logwarn('Still waiting for initial state from the camera. Cannot move yet')
@@ -191,14 +203,23 @@ class AxisPtzControlNode:
             self.ptz_srv.set_aborted(ptz_resp, "Status of Axis camera is stale; waiting for camera to publish its state again")
 
         else:
+            if self.ptz_state.mode == PtzState.MODE_VELOCITY:
+                self.vel_srv.set_aborted("Asserting position control")
+
             # The camera is alive and ready to move
             self.goal_pan = clamp(ptz_req.pan, self.min_pan, self.max_pan, 'pan')
             self.goal_tilt = clamp(ptz_req.tilt, self.min_tilt, self.max_tilt, 'tilt')
             self.goal_zoom = clamp(ptz_req.zoom, self.min_logical_zoom, self.max_logical_zoom, 'zoom')
 
             # send the command to the camera
-            self.command_axis()
-            self.set_is_moving(True)
+            self.is_moving = True
+            cmd = Ptz()
+            ptz.pan = self.goal_pan
+            ptz.tilt = self.goal_tilt
+            ptz.zoom = self.goal_zoom
+            self.cmd_vel_pub.publish(cmd)
+            self.last_command_at = rospy.Time.now()
+            self.ptz_state = PtzState.MODE_POSITION
 
             # sleep until joint_states reports that the pan and tilt joints have reached the desired position OR
             # have stopped moving
@@ -222,60 +243,87 @@ class AxisPtzControlNode:
                 self.ptz_srv.set_preempted()
             elif timed_out:
                 rospy.logwarn("Timed out waiting for axis camera state")
-                self.set_is_moving(False)
-                self.ptz_srv.success = False
+                self.is_moving = False
+                ptz_resp = PtzResult()
+                ptz_resp.success = False
+                self.ptz_state = PtzState.MODE_IDLE
                 self.ptz_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
             else:
                 rospy.logdebug("PTZ action completed successfully")
                 ptz_resp = PtzResult()
                 ptz_resp.success = True
+                self.ptz_state = PtzState.MODE_IDLE
                 self.ptz_srv.set_succeeded(ptz_resp)
 
 
-    ## Create the Axis.msg and send it to the camera hardware
-    def command_axis(self):
-        cmd = self.ptz_to_axis()
-        self.cmd_pub.publish(cmd)
-        self.last_command_at = rospy.Time.now()
+    def vel_actionHandler(self, ptz_req):
+        """Handles PTZ.action requests for velocity control
 
-    def set_is_moving(self, value):
-        self.is_moving_lock.acquire()
-        self.is_moving = value
-        self.is_moving_lock.release()
+        Converts the PTZ goal into an Axis.msg we write to the axis_camera driver
+        and then wait until the feedback topic reports that the PTU has finished moving
 
-    ## Convert the PtzResult to an Axis message we can write back to the driver
-    #
-    # \param  ptz_req   The PtzResult received from the service handler
-    # \return an Axis object corresponding to the requested PTZ position
-    def ptz_to_axis(self):
-        axis = Axis()
+        @param ptz_req  The PtzGoal object to process
+        """
+        if self.last_axis_state == None:
+            # We have never contacted the camera; block until we hear _something_
+            rospy.logwarn('Still waiting for initial state from the camera. Cannot move yet')
+            ptz_resp = PtzResult()
+            ptz_resp.success = False
+            self.vel_srv.set_aborted(ptz_resp, 'Still waiting for initial state from the camera. Cannot move yet')
+        elif rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
+            # We haven't heard from the camera in a while; block until the camera updates its status again
+            rospy.logwarn("Status of Axis camera is stale. Waiting for the camera to come back online")
+            ptz_resp = PtzResult()
+            ptz_resp.success = False
+            self.vel_srv.set_aborted(ptz_resp, "Status of Axis camera is stale; waiting for camera to publish its state again")
+        elif self.ptz_state.mode == PtzState.MODE_POSITION:
+            # We're processiung a position command; it must finish first
+            rospy.logwarn("Camera is moving under position control. Wait for that action to finish before using velocityu control")
+            ptz_resp = PtzResult()
+            ptz_resp.success = False
+            self.vel_srv.set_aborted(ptz_resp, "Camera is moving under position control")
+        else:
+            # The camera is alive and ready to move
+            cmd = Ptz()
+            cmd.pan = ptz_req.pan
+            cmd.tilt = ptz_req.tilt
+            cmd.zoom = ptz_req.zoom
+            self.is_moving = True
+            self.cmd_vel_pub.publish(cmd)
+            self.ptz_state.mode = PtzState.MODE_VELOCITY
 
-        pan = rad2deg(self.goal_pan)
-        tilt = rad2deg(self.goal_tilt)
-        zoom = linear_rescale(self.goal_zoom, self.min_logical_zoom, self.max_logical_zoom, self.min_hw_zoom, self.max_hw_zoom)
+            rate = rospy.Rate(2)
+            timed_out = False
+            while self.is_moving and not self.vel_srv.is_preempt_requested() and not timed_out:
+                feedback = PtzFeedback()
+                feedback.zoom_remaining = 0
+                feedback.pan_remaining = 0
+                feedback.tilt_remaining = 0
+                self.vel_srv.publish_feedback(feedback)
 
-        # by default the underlying Axis driver uses + as right, but we use
-        # + as left
-        if not self.invert_pan:
-            pan = -pan
+                if rospy.Time.now() - self.last_state_at > self.STATE_TIMEOUT:
+                    timed_out = True
+                else:
+                    rospy.logdebug(f"PTZ is still moving ({feedback.pan_remaining}, {feedback.tilt_remaining}, {feedback.zoom_remaining}) to go")
+                    rate.sleep()
 
-        # invert the tilt if necessary
-        if self.invert_tilt:
-            tilt = -tilt
-
-        # set the PTZ values
-        axis.pan = pan
-        axis.tilt = tilt
-        axis.zoom = zoom
-
-        # copy the other camera settings from the current state
-        axis.autofocus = self.last_axis_state.autofocus
-        axis.autoiris = self.last_axis_state.autoiris
-        axis.brightness = self.last_axis_state.brightness
-        axis.focus = self.last_axis_state.focus
-        axis.iris = self.last_axis_state.iris
-
-        return axis
+            if self.vel_srv.is_preempt_requested():
+                rospy.logwarn("Velocity action preempted")
+                self.is_moving = False
+                self.vel_srv.set_preempted()
+            elif timed_out:
+                rospy.logwarn("Timed out waiting for axis camera state")
+                self.is_moving = False
+                ptz_resp = PtzResult()
+                ptz_resp.success = False
+                self.vel_state = PtzState.MODE_IDLE
+                self.vel_srv.set_aborted(ptz_resp, "Timed out waiting for axis camera state; did the camera go offline?")
+            else:
+                rospy.logdebug("PTZ action completed successfully")
+                ptz_resp = PtzResult()
+                ptz_resp.success = True
+                self.ptz_state = PtzState.MODE_IDLE
+                self.ptz_srv.set_succeeded(ptz_resp)
 
 
 def main():

--- a/axis_ptz_action_server/scripts/axis_ptz_action_server_node
+++ b/axis_ptz_action_server/scripts/axis_ptz_action_server_node
@@ -3,9 +3,13 @@
 import actionlib
 import math
 import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
 
 from axis_msgs.msg import Ptz
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
 from threading import Lock, Thread
@@ -55,6 +59,8 @@ class AxisPtzControlNode:
         self.min_hw_zoom = rospy.get_param("~min_zoom", 1)
         self.max_hw_zoom = rospy.get_param("~max_zoom", 9999)
 
+        self.camera_base_link = rospy.get_param("~camera_base_link", "base_link")
+
         self.publish_joint_states = rospy.get_param("~publish_joint_states", True)
         self.pan_joint = rospy.get_param("~pan_joint", "pan_joint")
         self.tilt_joint = rospy.get_param("~tilt_joint", "tilt_joint")
@@ -90,6 +96,7 @@ class AxisPtzControlNode:
         self.ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
         self.ptz_rel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
         self.vel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/velocity', PtzAction, self.vel_actionHandler, False)
+        self.tf_ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs_tf', PtzRelTo, self.tf_ptz_abs_actionHandler, False)
 
         self.last_state_at = rospy.Time.now()
         self.last_command_at = rospy.Time.now()
@@ -110,6 +117,7 @@ class AxisPtzControlNode:
         self.ptz_abs_srv.start()
         self.ptz_rel_srv.start()
         self.vel_srv.start()
+        self.tf_ptz_abs_srv.start()
 
     def state_callback(self, data):
         """Monitors the position of the camera to determine if the pan and tilt joints have reached their
@@ -357,6 +365,69 @@ class AxisPtzControlNode:
                 self.is_moving = False
                 self.ptz_state.mode = PtzState.MODE_IDLE
                 self.vel_srv.set_succeeded(ptz_resp)
+
+    def tf_ptz_abs_actionHandler(self, ptz_req):
+        """Handler for a TF-aware absolute PTZ action
+
+        We calculate the TF between the camera's base link & the link provided in the request, and then use
+        the normal absolute PTZ action internally to move the camera to the corresponding position
+        """
+        # calculate the initial absolute goal as if there is no TF to apply
+        abs_goal = PtzGoal(ptz_req.pan,
+                           ptz_req.tilt,
+                           ptz_req.zoom
+        )
+
+        if ptz_req.frame_id:
+            try:
+                # The the RPY transformation between the camera base link & the reference frame
+                tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
+                tf_listener = tf2_ros.TransformListener(tf_buffer)
+                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+                q = tf_stamped.transform.rotation
+                (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
+
+                print(f"{roll} {pitch} {yaw}")
+
+                abs_goal.pan = abs_goal.pan + yaw
+                abs_goal.tilt = abs_goal.tilt + pitch
+
+                # clamp the adjusted pan to lie within [-pi, pi]
+                while abs_goal.pan < -math.pi:
+                    abs_goal.pan += math.pi
+                while abs_goal.pan < math.pi:
+                    abs_goal.pan -= math.pi
+
+                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+                while abs_goal.tilt < -math.pi/2:
+                    abs_goal.tilt += math.pi
+                while abs_goal.tilt < math.pi/2:
+                    abs_goal.tilt -= math.pi
+
+            except Exception as err:
+                rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")
+
+        ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+        ptz_client.wait_for_server()
+
+        def done_cb(state, result):
+            tf_result = PtzRelToResult(result.success)
+            if state == actionlib.GoalStatus.SUCCEEDED:
+                self.tf_ptz_abs_srv.set_succeeded(tf_result)
+            elif state == actionlib.GoalStatus.PREEMPTED:
+                self.tf_ptz_abs_srv.set_preempted()
+            else:
+                self.tf_ptz_abs_srv.set_aborted(tf_result)
+
+        def feedback_cb(fb):
+            tf_fb = PtzRelToFeedback(fb.pan_remaining, fb.tilt_remaining, fb.zoom_remaining)
+            self.tf_ptz_abs_srv.publish_feedback(tf_fb)
+
+        ptz_client.send_goal(abs_goal,
+            feedback_cb = feedback_cb,
+            done_cb = done_cb
+        )
+        ptz_client.wait_for_result()
 
 
 def main():

--- a/flir_ptu_action_server/README.md
+++ b/flir_ptu_action_server/README.md
@@ -12,8 +12,8 @@ Parameters
 -----------
 
 The `flir_ptu_action_server_node` takes the following parameters:
-- `cmd_topic` -- the name of the `JointState` topic provided by the `flir_ptu` package to move the unit. Default: `/ptu_driver/cmd`
-- `act_ns` -- the namespace of the `Ptz.action` actions the node provides. Default: `/ptu_driver/ptz_cmd`
+- `cmd_topic` -- the name of the `JointState` topic provided by the `flir_ptu` package to move the unit. Default: `/ptu/cmd`
+- `act_ns` -- the namespace of the `Ptz.action` actions the node provides. Default: `/ptu`
 - `pan_joint` -- the name of the pan joint as published in `/joint_states`. Default: `ptu_pan`
 - `tilt_joint` -- the name of the tilt joint as published in `/joint_states`. Default: `ptu_tilt`
 
@@ -25,7 +25,8 @@ Subscriptions
 Published Topics
 -----------------
 
-The node provides the `move_ptz` action with its corresponding `goal`, `feedback`, `result`, and `cancel` topics
-in the namespace defined by `act_ns` as described above.
+The node provides two actions within the `act_ns` namespace:
+- `move_ptz/position_abs`: send an absolute pan/tilt position (zoom is ignored)
+- `move_ptz/position_rel`: send a goal position relative to the current position (zoom is ignored)
 
 The current position of the PTU is published on `{act_ns}/ptz_state` using the `ptz_action_server_msgs/PtzPosition` message type.

--- a/flir_ptu_action_server/config/limits.yaml
+++ b/flir_ptu_action_server/config/limits.yaml
@@ -15,3 +15,11 @@ max_tilt: 0.5410520681182421
 # e.g. if a camera is mounted backwards the tilt may need to be inverted
 invert_pan: false
 invert_tilt: false
+
+# Zoom levels for PTZ interface
+# The PTU doesn't actually support zooming, so these parameters are only for any
+# automated external processes that check parameters (e.g. GUI controls)
+min_zoom: 1
+max_zoom: 1
+min_logical_zoom: 1
+max_logical_zoom: 1

--- a/flir_ptu_action_server/launch/flir_ptu_action_server_node.launch
+++ b/flir_ptu_action_server/launch/flir_ptu_action_server_node.launch
@@ -7,7 +7,7 @@
   <arg name="limits" default="$(find flir_ptu_action_server)/config/limits.yaml" />
 
   <group ns="$(arg act_ns)">
-    <node name="flir_ptu_action_server_node" pkg="flir_ptu_action_server" type="flir_ptu_action_server_node">
+    <node name="ptz_action_server_node" pkg="flir_ptu_action_server" type="flir_ptu_action_server_node">
       <param name="cmd_topic" value="$(arg cmd_topic)" />
       <param name="pan_joint" value="$(arg pan_joint)" />
       <param name="tilt_joint" value="$(arg tilt_joint)" />

--- a/flir_ptu_action_server/package.xml
+++ b/flir_ptu_action_server/package.xml
@@ -9,15 +9,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-
-  <depend>ptz_action_server_msgs</depend>
-  <depend>rospy</depend>
-  <depend>actionlib_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
-
-  <exec_depend>flir_ptu_driver</exec_depend>
   <exec_depend>actionlib</exec_depend>
+  <exec_depend>flir_ptu_driver</exec_depend>
+  <exec_depend>ptz_action_server_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
   </export>

--- a/flir_ptu_action_server/scripts/flir_ptu_action_server_node
+++ b/flir_ptu_action_server/scripts/flir_ptu_action_server_node
@@ -4,7 +4,7 @@ import rospy
 import actionlib
 
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
-from ptz_action_server_msgs.msg import PtzPosition
+from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import JointState
 
 from math import pi
@@ -54,14 +54,14 @@ class FlirD46PtzControlNode:
 
         self.is_moving = False
 
-        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz', PtzAction, self.ptz_actionHandler, False)
+        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/position', PtzAction, self.ptz_actionHandler, False)
 
 
     ## Starts the subscribers, publishers, and service handlers
     def start(self):
         self.cmd_pub = rospy.Publisher(self.cmd_topic, JointState, queue_size=1)
         self.joint_state_sub = rospy.Subscriber('/joint_states', JointState, joint_state_callback, self)
-        self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzPosition, queue_size=1)
+        self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzState, queue_size=1)
         self.ptz_srv.start()
 
 
@@ -153,10 +153,14 @@ class FlirD46PtzControlNode:
             self.current_tilt = tilt
 
             # publish the current PTZ state
-            state = PtzPosition()
+            state = PtzState()
             state.pan = pan
             state.tilt = tilt
             state.zoom = 0
+            if self.is_moving:
+                state.mode = PtzState.MODE_POSITION
+            else:
+                state.mode = PtzState.MODE_IDLE
             self.status_pub.publish(state)
 
             if self.is_moving and (\

--- a/flir_ptu_action_server/scripts/flir_ptu_action_server_node
+++ b/flir_ptu_action_server/scripts/flir_ptu_action_server_node
@@ -22,8 +22,10 @@ def clamp_value(x, min, max, metavar='pan'):
     else:
         return x
 
-## Provides a PTZ.action compatible interface for sending pan-tilt positions to the flir_ptu driver
 class FlirD46PtzControlNode:
+    """Provides a PTZ.action compatible interface for sending pan-tilt positions to the flir_ptu driver
+    """
+
     HW_MIN_PAN = -2.775073510670984
     HW_MAX_PAN = 2.775073510670984
 
@@ -54,23 +56,26 @@ class FlirD46PtzControlNode:
 
         self.is_moving = False
 
-        self.ptz_srv = actionlib.SimpleActionServer(f'{self.act_ns}/position', PtzAction, self.ptz_actionHandler, False)
+        self.ptz_abs_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
+        self.ptz_rel_srv = actionlib.SimpleActionServer(f'{self.act_ns}/move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
 
-
-    ## Starts the subscribers, publishers, and service handlers
     def start(self):
+        """Starts the subscribers, publishers, and service handlers
+        """
         self.cmd_pub = rospy.Publisher(self.cmd_topic, JointState, queue_size=1)
         self.joint_state_sub = rospy.Subscriber('/joint_states', JointState, joint_state_callback, self)
         self.status_pub = rospy.Publisher(f'{self.act_ns}/ptz_state', PtzState, queue_size=1)
-        self.ptz_srv.start()
+        self.ptz_abs_srv.start()
+        self.ptz_rel_srv.start()
 
+    def ptz_abs_actionHandler(self, ptz_req):
+        """Handler for the PTZ.action call
 
-    ## Handler for the PTZ.action call
-    #  Converts the PTZ request into a JointState we write to the flir_ptu driver
-    #  and then wait until /joint_states reports that the PTU has finished moving
-    #
-    #  \param ptz_req  The PtzActionGoal object to process
-    def ptz_actionHandler(self, ptz_req):
+        Converts the PTZ request into a JointState we write to the flir_ptu driver
+        and then wait until /joint_states reports that the PTU has finished moving
+
+        @param ptz_req  The PtzActionGoal object to process
+        """
         # make sure the requested position is valid
         pan = clamp_value(ptz_req.pan, self.MIN_PAN, self.MAX_PAN, 'pan')
         tilt = clamp_value(ptz_req.tilt, self.MIN_PAN, self.MAX_TILT, 'tilt')
@@ -92,35 +97,58 @@ class FlirD46PtzControlNode:
         # To avoid the action server hanging, implement a hard timeout
         MAX_WAIT = 60.0         # moving from -135 to + 135 takes ~50s.
         elapsed_wait = 0.0
-        while self.is_moving and not self.ptz_srv.is_preempt_requested() and elapsed_wait < MAX_WAIT:
+        while self.is_moving and not self.ptz_abs_srv.is_preempt_requested() and elapsed_wait < MAX_WAIT:
             feedback = PtzFeedback()
             feedback.zoom_remaining = 0.0
             feedback.pan_remaining = self.goal_pan - self.current_pan
             feedback.tilt_remaining = self.goal_tilt - self.current_tilt
-            self.ptz_srv.publish_feedback(feedback)
+            self.ptz_abs_srv.publish_feedback(feedback)
             rate.sleep()
             elapsed_wait = elapsed_wait + 0.1   # rate is 10Hz, so each spin is 0.1s
 
-        if self.ptz_srv.is_preempt_requested():
+        if self.ptz_abs_srv.is_preempt_requested():
             rospy.logwarn("PTZ action cancelled")
             self.is_moving = False
-            self.ptz_srv.set_preempted()
+            self.ptz_abs_srv.set_preempted()
         elif elapsed_wait >= MAX_WAIT:
             rospy.logwarn("PTZ action timed out.  Assuming movement is complete")
             self.is_moving = False
             ptz_resp = PtzResult()
             ptz_resp.success = True
-            self.ptz_srv.set_succeeded(ptz_resp)
+            self.ptz_abs_srv.set_succeeded(ptz_resp)
         else:
             ptz_resp = PtzResult()
             ptz_resp.success = True
-            self.ptz_srv.set_succeeded(ptz_resp)
+            self.ptz_abs_srv.set_succeeded(ptz_resp)
 
+    def ptz_rel_actionHandler(self, ptz_req):
+        """Handler for moving the camera to a relative pan/tilt/zoom from current
 
-    ## Monitors /joint_states to determine if the pan and tilt joints have reached their goal positions yet
-    #
-    # \param data  The JointState information received on /joint_states
+        Converts the relative pan/tilt to absolute positions and uses the position_abs action
+        """
+        abs_goal = PtzGoal(self.current_pan + ptz_req.pan, self.current_tilt + ptz_req.tilt, 0)
+        ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+        ptz_client.wait_for_server()
+
+        def done_cb(state, result):
+            if state == actionlib.GoalStatus.SUCCEEDED:
+                self.ptz_rel_srv.set_succeeded(result)
+            elif state == actionlib.GoalStatus.PREEMPTED:
+                self.ptz_rel_srv.set_preempted()
+            else:
+                self.ptz_rel_srv.set_aborted(result)
+
+        ptz_client.send_goal(abs_goal,
+            feedback_cb = lambda fb: self.ptz_rel_srv.publish_feedback(fb),
+            done_cb = done_cb
+        )
+        ptz_client.wait_for_result()
+
     def joint_state_callback(self, data):
+        """Monitors /joint_states to determine if the pan and tilt joints have reached their goal positions yet
+
+        @param data  The JointState information received on /joint_states
+        """
         try:
             pan_index = data.name.index(self.pan_joint)
             tilt_index = data.name.index(self.tilt_joint)
@@ -176,14 +204,13 @@ class FlirD46PtzControlNode:
         except Exception as err:
             rospy.logerror(err)
 
-
-    ## Convert the PtzResult to a JointState we can write back to the driver
-    #
-    # \param  goal_pan   The desired pan angle, in radians
-    # \param  goal_tilt  The desired tilt angle, in radians
-    # \return a JointState object corresponding to the requested PTZ position
     def mk_joint_state(self, goal_pan, goal_tilt):
+        """Convert the PtzResult to a JointState we can write back to the driver
 
+        @param  goal_pan   The desired pan angle, in radians
+        @param  goal_tilt  The desired tilt angle, in radians
+        @return a JointState object corresponding to the requested PTZ position
+        """
         # convert from the action coordinate range to the hardware coordiante range
         if self.INVERT_PAN:
             goal_pan = -goal_pan

--- a/ptz_action_server_msgs/CMakeLists.txt
+++ b/ptz_action_server_msgs/CMakeLists.txt
@@ -14,7 +14,7 @@ add_action_files(
 
 add_message_files(
   FILES
-  PtzPosition.msg
+  PtzState.msg
 )
 
 generate_messages(

--- a/ptz_action_server_msgs/CMakeLists.txt
+++ b/ptz_action_server_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_action_files(
   FILES
   Ptz.action
+  PtzFrame.action
   PtzRelTo.action
 )
 

--- a/ptz_action_server_msgs/CMakeLists.txt
+++ b/ptz_action_server_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_action_files(
   FILES
   Ptz.action
+  PtzRelTo.action
 )
 
 add_message_files(

--- a/ptz_action_server_msgs/action/PtzFrame.action
+++ b/ptz_action_server_msgs/action/PtzFrame.action
@@ -1,0 +1,11 @@
+# A frame ID we want to point the camera at
+string frame_id
+
+# The zoom level we want
+float32 zoom
+---
+bool success
+---
+float32 pan_remaining
+float32 tilt_remaining
+float32 zoom_remaining

--- a/ptz_action_server_msgs/action/PtzRelTo.action
+++ b/ptz_action_server_msgs/action/PtzRelTo.action
@@ -1,0 +1,13 @@
+float32 pan
+float32 tilt
+float32 zoom
+
+# A frame ID that we calculate the pan & tilt relative to
+# If blank the link ID is ignored and we treat this request as a normal PtzAction
+string frame_id
+---
+bool success
+---
+float32 pan_remaining
+float32 tilt_remaining
+float32 zoom_remaining

--- a/ptz_action_server_msgs/msg/PtzPosition.msg
+++ b/ptz_action_server_msgs/msg/PtzPosition.msg
@@ -1,4 +1,0 @@
-# The current position of a PTZ camera or PTU
-float32 pan
-float32 tilt
-float32 zoom

--- a/ptz_action_server_msgs/msg/PtzState.msg
+++ b/ptz_action_server_msgs/msg/PtzState.msg
@@ -1,0 +1,16 @@
+# The device is not currently moving
+int8 MODE_IDLE=0
+
+# The device is moving under position control
+int8 MODE_POSITION=1
+
+# The device is moving under velocity control
+int8 MODE_VELOCITY=2
+
+# The device's current operating mode
+int8 mode
+
+# The current position or velocity of a PTZ camera or PTU
+float32 pan
+float32 tilt
+float32 zoom

--- a/simulated_ptz_action_server/README.md
+++ b/simulated_ptz_action_server/README.md
@@ -18,7 +18,12 @@ roslaunch simulated_ptz_action_server simulated_ptz_action_server.launch
 The digitally-zoomed camera data will be available on `/sensor/camera_0/image_raw` and the PTZ actions are
 available in `/sensors/camera_0/move_ptz`.
 
-To control the camera, simply connect your `actionlib` client to the `/sensors/camera_0/move_ptz` action.
+The node provides two `actionlib` servers:
+- `move_ptz/position_abs`: sends an absolute pan/tilt/zoom destination for the camera to move to
+- `move_ptz/position_rel`: sends a desired pan/tilt/zoom destination relative to the camera's current position
+
+To control the camera, simply connect your `actionlib` client to the appropriate absolute or relative action server
+above and send goals.
 
 
 URDF Configuration & PID Controllers

--- a/simulated_ptz_action_server/config/limits.yaml
+++ b/simulated_ptz_action_server/config/limits.yaml
@@ -1,0 +1,15 @@
+# Pan/Tilt/Zoom limits for the simulated camera
+# -179 to 179
+min_pan: -3.14159
+max_pan: 3.12413936106985
+# -90 to 90
+min_tilt: -1.5707963267948966
+max_tilt: 1.5707963267948966
+# 5x digital zoom applied to the simulated camera stream
+min_logical_zoom: 1
+max_logical_zoom: 5
+
+# Hardware zoom limits are ignored by the action server node
+# These parameters exist only to keep consistency with the Axis and Flir action server nodes
+min_zoom: 1
+max_zoom: 5

--- a/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
+++ b/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
@@ -7,6 +7,6 @@
         args="pan_position_controller tilt_position_controller"/>
 
   <group ns="$(arg camera_ns)">
-    <node name="ptz_action_server" pkg="simulated_ptz_action_server" type="ptz_camera_sim_node" />
+    <node name="ptz_action_server_node" pkg="simulated_ptz_action_server" type="ptz_camera_sim_node" />
   </group>
 </launch>

--- a/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
+++ b/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
@@ -1,12 +1,15 @@
 <?xml version="1.0" ?>
 <launch>
   <arg name="camera_ns" default="/sensors/camera_0" />
+  <arg name="limits_config" default="$(find simulated_ptz_action_server)/config/limits.yaml" />
 
   <rosparam command="load" file="$(find simulated_ptz_action_server)/config/ptz_controllers.yaml" />
   <node name="ptz_action_server_spawner" pkg="controller_manager" type="spawner"
         args="pan_position_controller tilt_position_controller"/>
 
   <group ns="$(arg camera_ns)">
-    <node name="ptz_action_server_node" pkg="simulated_ptz_action_server" type="ptz_camera_sim_node" />
+    <node name="ptz_action_server_node" pkg="simulated_ptz_action_server" type="ptz_camera_sim_node">
+      <rosparam command="load" file="$(arg limits_config)" subst_value="true" />
+    </node>
   </group>
 </launch>

--- a/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
+++ b/simulated_ptz_action_server/launch/simulated_ptz_action_server.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="camera_ns" default="/sensors/camera_0" />
   <arg name="limits_config" default="$(find simulated_ptz_action_server)/config/limits.yaml" />
+  <arg name="camera_name" default="ptz_camera" />
 
   <rosparam command="load" file="$(find simulated_ptz_action_server)/config/ptz_controllers.yaml" />
   <node name="ptz_action_server_spawner" pkg="controller_manager" type="spawner"
@@ -9,6 +10,7 @@
 
   <group ns="$(arg camera_ns)">
     <node name="ptz_action_server_node" pkg="simulated_ptz_action_server" type="ptz_camera_sim_node">
+      <param name="camera_base_link" value="$(arg camera_name)_base_link" />
       <rosparam command="load" file="$(arg limits_config)" subst_value="true" />
     </node>
   </group>

--- a/simulated_ptz_action_server/package.xml
+++ b/simulated_ptz_action_server/package.xml
@@ -17,6 +17,10 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <export>
   </export>

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -4,7 +4,7 @@ import actionlib
 import math
 import rospy
 
-from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import Image, JointState
 from std_msgs.msg import Float64
@@ -13,15 +13,16 @@ import cv2
 from cv_bridge import CvBridge, CvBridgeError
 
 
-## Node that implements the PTZ action server for a simulated camera
-#
-#  Actual camera data and joint states are provided by Gazebo plugins
-#  We use a velocity_controllers/JointPositionController to control the actual pan and tilt
-#  joints, subscribing to /joint_states to determine when the camera has finished moving after
-#  receiving a command.
-#
-#  Zoom is implemented as a digital zoom, so expect poor resolution at higher levels.
 class SimulatedPtzCameraNode:
+    """Node that implements the PTZ action server for a simulated camera
+
+    Actual camera data and joint states are provided by Gazebo plugins
+    We use a velocity_controllers/JointPositionController to control the actual pan and tilt
+    joints, subscribing to /joint_states to determine when the camera has finished moving after
+    receiving a command.
+
+    Zoom is implemented as a digital zoom, so expect poor resolution at higher levels.
+    """
     def __init__(self):
         self.pan_limits = rospy.get_param('~pan_limits', [-2*math.pi, 2*math.pi])    # -180 to 180
         self.tilt_limits = rospy.get_param('~tilt_limits', [-math.pi/6, math.pi/2])  # -30 to 90
@@ -30,15 +31,17 @@ class SimulatedPtzCameraNode:
         self.current_pan = 0.0
         self.current_tilt = 0.0
         self.current_zoom = 1.0
+        self.is_moving = False
+        self.is_zooming = False
 
         self.ANGLE_TOLERANCE = 1.0 * math.pi / 180.0  # allow 1 degree either way for PTZ commands\
         self.ZOOM_RATE = 0.1
 
         self.bridge = CvBridge()
 
-
-    ## Start the action server, begin publishing the joint states
     def run(self):
+        """Start the action server, begin publishing the joint states
+        """
         self.position_sub = rospy.Subscriber('/joint_states', JointState, self.joint_state_callback)
         self.img_sub = rospy.Subscriber('image_raw_nozoom', Image, self.image_callback)
         self.img_pub = rospy.Publisher('image_raw', Image, queue_size=1)
@@ -47,8 +50,10 @@ class SimulatedPtzCameraNode:
         self.pan_cmd = rospy.Publisher('/pan_position_controller/command', Float64, queue_size=1)
         self.tilt_cmd = rospy.Publisher('/tilt_position_controller/command', Float64, queue_size=1)
 
-        self.ptz_srv = actionlib.SimpleActionServer('position', PtzAction, self.ptz_actionHandler, False)
-        self.ptz_srv.start()
+        self.ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
+        self.ptz_rel_srv = actionlib.SimpleActionServer('move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
+        self.ptz_abs_srv.start()
+        self.ptz_rel_srv.start()
 
         # spin and publish the ptz status at 10Hz
         rate = rospy.Rate(10)
@@ -66,12 +71,12 @@ class SimulatedPtzCameraNode:
 
             rate.sleep()
 
+    def ptz_abs_actionHandler(self, req):
+        """Handler for moving the camera to an absolute pan/tilt/zoom
 
-    ## Handler for the move_ptz action
-    #
-    #  Sends the desired pan & tilt positions to the JointPositionControllers and publishes feedback at 10Hz
-    #  until the camera reaches the desired position
-    def ptz_actionHandler(self, req):
+        Sends the desired pan & tilt positions to the JointPositionControllers and publishes feedback at 10Hz
+        until the camera reaches the desired position
+        """
         goal_pan = req.pan
         if goal_pan < self.pan_limits[0]:
             rospy.logwarn(f"Pan of {req.pan} is too small; clamping to {self.pan_limits[0]}")
@@ -144,7 +149,7 @@ class SimulatedPtzCameraNode:
             fback.pan_remaining = pan_to_go
             fback.tilt_remaining = tilt_to_go
             fback.zoom_remaining = zoom_to_go
-            self.ptz_srv.publish_feedback(fback)
+            self.ptz_abs_srv.publish_feedback(fback)
 
         if rospy.is_shutdown():
             rospy.loginfo("Node shutting down")
@@ -152,15 +157,45 @@ class SimulatedPtzCameraNode:
             rospy.logwarn("PTZ action failed")
             ptz_resp = PtzResult()
             ptz_resp.success = False
-            self.ptz_srv.set_succeeded(ptz_resp)
+            self.ptz_abs_srv.set_succeeded(ptz_resp)
         else:
             rospy.loginfo("PTZ simulator reached goal position")
             ptz_resp = PtzResult()
             ptz_resp.success = True
-            self.ptz_srv.set_succeeded(ptz_resp)
+            self.ptz_abs_srv.set_succeeded(ptz_resp)
 
-    ## Read the current joint_states and update the camera's current position
+
+    def ptz_rel_actionHandler(self, ptz_req):
+        """Handler for moving the camera to a relative pan/tilt/zoom from current
+
+        Converts the relative pan/tilt/zoom to absolute positions and uses the position_abs action
+        """
+        abs_goal = PtzGoal(self.current_pan + ptz_req.pan,
+                                 self.current_tilt + ptz_req.tilt,
+                                 self.current_zoom + ptz_req.zoom
+        )
+
+        ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+        ptz_client.wait_for_server()
+
+        def done_cb(state, result):
+            if state == actionlib.GoalStatus.SUCCEEDED:
+                self.ptz_rel_srv.set_succeeded(result)
+            elif state == actionlib.GoalStatus.PREEMPTED:
+                self.ptz_rel_srv.set_preempted()
+            else:
+                self.ptz_rel_srv.set_aborted(result)
+
+        ptz_client.send_goal(abs_goal,
+            feedback_cb = lambda fb: self.ptz_rel_srv.publish_feedback(fb),
+            done_cb = done_cb
+        )
+        ptz_client.wait_for_result()
+
+
     def joint_state_callback(self, data):
+        """Read the current joint_states and update the camera's current position
+        """
         if 'ptz_camera_pan_joint' in data.name:
             index = data.name.index('ptz_camera_pan_joint')
             self.current_pan = data.position[index]
@@ -169,9 +204,9 @@ class SimulatedPtzCameraNode:
             index = data.name.index('ptz_camera_tilt_joint')
             self.current_tilt = data.position[index]
 
-
-    ## Apply a digital zoom to the input image and republish it
     def image_callback(self, img):
+        """Apply a digital zoom to the input image and republish it
+        """
         if self.current_zoom != 1.0:
             # convert to OpenCV, zoom into the middle, convert back to ROS, and publish
             try:

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -24,9 +24,18 @@ class SimulatedPtzCameraNode:
     Zoom is implemented as a digital zoom, so expect poor resolution at higher levels.
     """
     def __init__(self):
-        self.pan_limits = rospy.get_param('~pan_limits', [-2*math.pi, 2*math.pi])    # -180 to 180
-        self.tilt_limits = rospy.get_param('~tilt_limits', [-math.pi/6, math.pi/2])  # -30 to 90
-        self.zoom_limits = rospy.get_param('~zoom_limits', [1, 5])                   # 1x to 5x zoom
+        self.pan_limits = [
+            rospy.get_param('~min_pan', -math.pi),
+            rospy.get_param('~max_pan', math.pi)
+        ]
+        self.tilt_limits = [
+            rospy.get_param('~min_tilt', -math.pi/2),
+            rospy.get_param('~max_tilt', math.pi/2)
+        ]
+        self.zoom_limits = [
+            rospy.get_param('~min_logical_zoom', 1),
+            rospy.get_param('~max_logical_zoom', 5)
+        ]
 
         self.current_pan = 0.0
         self.current_tilt = 0.0

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -230,22 +230,15 @@ class SimulatedPtzCameraNode:
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                print(f"{roll} {pitch} {yaw}")
-
-                abs_goal.pan = abs_goal.pan + yaw
-                abs_goal.tilt = abs_goal.tilt + pitch
+                if abs(roll) > deg2rad(5) or abs(pitch) > deg2rad(5):
+                    rospy.logwarn(f"{self.camera_base_link} and {ptz_req.frame_id} are not coplanar; pitch errors may result")
 
                 # clamp the adjusted pan to lie within [-pi, pi]
+                abs_goal.pan = abs_goal.pan + yaw
                 while abs_goal.pan < -math.pi:
                     abs_goal.pan += math.pi
                 while abs_goal.pan < math.pi:
                     abs_goal.pan -= math.pi
-
-                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
-                while abs_goal.tilt < -math.pi/2:
-                    abs_goal.tilt += math.pi
-                while abs_goal.tilt < math.pi/2:
-                    abs_goal.tilt -= math.pi
 
             except Exception as err:
                 rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -3,8 +3,12 @@
 import actionlib
 import math
 import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
 
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import Image, JointState
 from std_msgs.msg import Float64
@@ -37,6 +41,8 @@ class SimulatedPtzCameraNode:
             rospy.get_param('~max_logical_zoom', 5)
         ]
 
+        self.camera_base_link = rospy.get_param("~camera_base_link", "base_link")
+
         self.current_pan = 0.0
         self.current_tilt = 0.0
         self.current_zoom = 1.0
@@ -61,8 +67,10 @@ class SimulatedPtzCameraNode:
 
         self.ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
         self.ptz_rel_srv = actionlib.SimpleActionServer('move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
+        self.tf_ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs_tf', PtzRelToAction, self.tf_ptz_abs_actionHandler, False)
         self.ptz_abs_srv.start()
         self.ptz_rel_srv.start()
+        self.tf_ptz_abs_srv.start()
 
         # spin and publish the ptz status at 10Hz
         rate = rospy.Rate(10)
@@ -201,6 +209,68 @@ class SimulatedPtzCameraNode:
         )
         ptz_client.wait_for_result()
 
+    def tf_ptz_abs_actionHandler(self, ptz_req):
+        """Handler for a TF-aware absolute PTZ action
+
+        We calculate the TF between the camera's base link & the link provided in the request, and then use
+        the normal absolute PTZ action internally to move the camera to the corresponding position
+        """
+        # calculate the initial absolute goal as if there is no TF to apply
+        abs_goal = PtzGoal(ptz_req.pan,
+                           ptz_req.tilt,
+                           ptz_req.zoom
+        )
+
+        if ptz_req.frame_id:
+            try:
+                # The the RPY transformation between the camera base link & the reference frame
+                tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
+                tf_listener = tf2_ros.TransformListener(tf_buffer)
+                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+                q = tf_stamped.transform.rotation
+                (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
+
+                print(f"{roll} {pitch} {yaw}")
+
+                abs_goal.pan = abs_goal.pan + yaw
+                abs_goal.tilt = abs_goal.tilt + pitch
+
+                # clamp the adjusted pan to lie within [-pi, pi]
+                while abs_goal.pan < -math.pi:
+                    abs_goal.pan += math.pi
+                while abs_goal.pan < math.pi:
+                    abs_goal.pan -= math.pi
+
+                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+                while abs_goal.tilt < -math.pi/2:
+                    abs_goal.tilt += math.pi
+                while abs_goal.tilt < math.pi/2:
+                    abs_goal.tilt -= math.pi
+
+            except Exception as err:
+                rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")
+
+        ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+        ptz_client.wait_for_server()
+
+        def done_cb(state, result):
+            tf_result = PtzRelToResult(result.success)
+            if state == actionlib.GoalStatus.SUCCEEDED:
+                self.tf_ptz_abs_srv.set_succeeded(tf_result)
+            elif state == actionlib.GoalStatus.PREEMPTED:
+                self.tf_ptz_abs_srv.set_preempted()
+            else:
+                self.tf_ptz_abs_srv.set_aborted(tf_result)
+
+        def feedback_cb(fb):
+            tf_fb = PtzRelToFeedback(fb.pan_remaining, fb.tilt_remaining, fb.zoom_remaining)
+            self.tf_ptz_abs_srv.publish_feedback(tf_fb)
+
+        ptz_client.send_goal(abs_goal,
+            feedback_cb = feedback_cb,
+            done_cb = done_cb
+        )
+        ptz_client.wait_for_result()
 
     def joint_state_callback(self, data):
         """Read the current joint_states and update the camera's current position

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -10,6 +10,7 @@ import uuid
 
 from geometry_msgs.msg import TransformStamped
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
+from ptz_action_server_msgs.msg import PtzFrameAction, PtzFrameFeedback, PtzFrameGoal, PtzFrameResult
 from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import Image, JointState
@@ -56,6 +57,11 @@ class SimulatedPtzCameraNode:
 
         self.bridge = CvBridge()
 
+        self.ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
+        self.ptz_rel_srv = actionlib.SimpleActionServer('move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
+        self.tf_ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs_tf', PtzRelToAction, self.tf_ptz_abs_actionHandler, False)
+        self.frame_ptz_srv = actionlib.SimpleActionServer('move_ptz/frame', PtzFrameAction, self.frame_ptz_actionHandler, False)
+
     def run(self):
         """Start the action server, begin publishing the joint states
         """
@@ -67,12 +73,10 @@ class SimulatedPtzCameraNode:
         self.pan_cmd = rospy.Publisher('/pan_position_controller/command', Float64, queue_size=1)
         self.tilt_cmd = rospy.Publisher('/tilt_position_controller/command', Float64, queue_size=1)
 
-        self.ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs', PtzAction, self.ptz_abs_actionHandler, False)
-        self.ptz_rel_srv = actionlib.SimpleActionServer('move_ptz/position_rel', PtzAction, self.ptz_rel_actionHandler, False)
-        self.tf_ptz_abs_srv = actionlib.SimpleActionServer('move_ptz/position_abs_tf', PtzRelToAction, self.tf_ptz_abs_actionHandler, False)
         self.ptz_abs_srv.start()
         self.ptz_rel_srv.start()
         self.tf_ptz_abs_srv.start()
+        self.frame_ptz_srv.start()
 
         self.tf_broadcaster = tf2_ros.StaticTransformBroadcaster()
         self.camera_vector_frame = f"camera_vector_frame_{str(uuid.uuid1()).replace('-', '_')}"
@@ -287,6 +291,70 @@ class SimulatedPtzCameraNode:
             done_cb = done_cb
         )
         ptz_client.wait_for_result()
+
+    def frame_ptz_actionHandler(self, ptz_req):
+        """Pan & tilt the camera to point to a specific frame in the TF tree
+        """
+        abs_goal = PtzGoal()
+        abs_goal.zoom = ptz_req.zoom
+
+        try:
+            # The the transformation between the camera base link & the reference frame
+            tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
+            tf_listener = tf2_ros.TransformListener(tf_buffer)
+            tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+
+            # we want to get the pan & tilt needed to point at the frame
+            r = math.sqrt(tf_stamped.transform.translation.x**2 + tf_stamped.transform.translation.y**2 + tf_stamped.transform.translation.z**2)
+            yaw = math.atan2(tf_stamped.transform.translation.y, tf_stamped.transform.translation.x)
+            pitch = -math.asin(tf_stamped.transform.translation.z/r)
+
+            # yaw & pitch are right-handed, but pan & tilt are left-handed, so invert them
+            abs_goal.pan = -yaw
+            abs_goal.tilt = -pitch
+
+            # clamp the adjusted pan to lie within [-pi, pi]
+            while abs_goal.pan < -math.pi:
+                abs_goal.pan += math.pi
+            while abs_goal.pan > math.pi:
+                abs_goal.pan -= math.pi
+
+            # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+            while abs_goal.tilt < -math.pi/2:
+                abs_goal.tilt += math.pi
+            while abs_goal.tilt > math.pi/2:
+                abs_goal.tilt -= math.pi
+
+            print(abs_goal)
+
+            ptz_client = actionlib.SimpleActionClient("move_ptz/position_abs", PtzAction)
+            ptz_client.wait_for_server()
+
+            def done_cb(state, result):
+                tf_result = PtzFrameResult(result.success)
+                if state == actionlib.GoalStatus.SUCCEEDED:
+                    self.frame_ptz_srv.set_succeeded(tf_result)
+                elif state == actionlib.GoalStatus.PREEMPTED:
+                    self.frame_ptz_srv.set_preempted()
+                else:
+                    self.frame_ptz_srv.set_aborted(tf_result)
+
+            def feedback_cb(fb):
+                tf_fb = PtzFrameFeedback(fb.pan_remaining, fb.tilt_remaining, fb.zoom_remaining)
+                self.frame_ptz_srv.publish_feedback(tf_fb)
+
+            ptz_client.send_goal(abs_goal,
+                feedback_cb = feedback_cb,
+                done_cb = done_cb
+            )
+            ptz_client.wait_for_result()
+
+        except Exception as err:
+            err_msg = f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}"
+            rospy.logerr(err_msg)
+            result = PtzFrameResult()
+            result.success = False
+            self.frame_ptz_srv.set_aborted(result, err_msg)
 
     def joint_state_callback(self, data):
         """Read the current joint_states and update the camera's current position

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -6,7 +6,9 @@ import rospy
 import tf2_ros
 import tf2_geometry_msgs
 import tf.transformations
+import uuid
 
+from geometry_msgs.msg import TransformStamped
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzGoal, PtzResult
 from ptz_action_server_msgs.msg import PtzRelToAction, PtzRelToFeedback, PtzRelToGoal, PtzRelToResult
 from ptz_action_server_msgs.msg import PtzState
@@ -71,6 +73,9 @@ class SimulatedPtzCameraNode:
         self.ptz_abs_srv.start()
         self.ptz_rel_srv.start()
         self.tf_ptz_abs_srv.start()
+
+        self.tf_broadcaster = tf2_ros.StaticTransformBroadcaster()
+        self.camera_vector_frame = f"camera_vector_frame_{str(uuid.uuid1()).replace('-', '_')}"
 
         # spin and publish the ptz status at 10Hz
         rate = rospy.Rate(10)
@@ -223,22 +228,39 @@ class SimulatedPtzCameraNode:
 
         if ptz_req.frame_id:
             try:
+                # add a temporary frame to represent the desired camera vector
+                camera_vector_q = tf.transformations.quaternion_from_euler(0, -ptz_req.tilt, ptz_req.pan)
+                static_tf = TransformStamped()
+                static_tf.header.stamp = rospy.Time.now()
+                static_tf.header.frame_id = ptz_req.frame_id
+                static_tf.child_frame_id = self.camera_vector_frame
+                static_tf.transform.rotation.x = camera_vector_q[0]
+                static_tf.transform.rotation.y = camera_vector_q[1]
+                static_tf.transform.rotation.z = camera_vector_q[2]
+                static_tf.transform.rotation.w = camera_vector_q[3]
+                self.tf_broadcaster.sendTransform(static_tf)
+
                 # The the RPY transformation between the camera base link & the reference frame
                 tf_buffer = tf2_ros.Buffer(rospy.Duration(100.0))
                 tf_listener = tf2_ros.TransformListener(tf_buffer)
-                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, ptz_req.frame_id, rospy.Time(0), rospy.Duration(5.0))
+                tf_stamped = tf_buffer.lookup_transform(self.camera_base_link, self.camera_vector_frame, rospy.Time(0), rospy.Duration(5.0))
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                if abs(roll) > deg2rad(5) or abs(pitch) > deg2rad(5):
-                    rospy.logwarn(f"{self.camera_base_link} and {ptz_req.frame_id} are not coplanar; pitch errors may result")
+                abs_goal.pan = yaw
+                abs_goal.tilt = -pitch
 
                 # clamp the adjusted pan to lie within [-pi, pi]
-                abs_goal.pan = abs_goal.pan + yaw
                 while abs_goal.pan < -math.pi:
                     abs_goal.pan += math.pi
-                while abs_goal.pan < math.pi:
+                while abs_goal.pan > math.pi:
                     abs_goal.pan -= math.pi
+
+                # clamp the adjusted tilt to lie within [-pi/2, pi/2]
+                while abs_goal.tilt < -math.pi/2:
+                    abs_goal.tilt += math.pi
+                while abs_goal.tilt > math.pi/2:
+                    abs_goal.tilt -= math.pi
 
             except Exception as err:
                 rospy.logerr(f"Failed to look up transform between {self.camera_base_link} and {ptz_req.frame_id}: {err}")

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -247,7 +247,8 @@ class SimulatedPtzCameraNode:
                 q = tf_stamped.transform.rotation
                 (roll, pitch, yaw) = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
 
-                abs_goal.pan = yaw
+                # yaw & pitch are right-handed, but pan & tilt are left-handed, so invert them
+                abs_goal.pan = -yaw
                 abs_goal.tilt = -pitch
 
                 # clamp the adjusted pan to lie within [-pi, pi]

--- a/simulated_ptz_action_server/scripts/ptz_camera_sim_node
+++ b/simulated_ptz_action_server/scripts/ptz_camera_sim_node
@@ -5,7 +5,7 @@ import math
 import rospy
 
 from ptz_action_server_msgs.msg import PtzAction, PtzFeedback, PtzActionGoal, PtzResult
-from ptz_action_server_msgs.msg import PtzPosition
+from ptz_action_server_msgs.msg import PtzState
 from sensor_msgs.msg import Image, JointState
 from std_msgs.msg import Float64
 
@@ -42,21 +42,26 @@ class SimulatedPtzCameraNode:
         self.position_sub = rospy.Subscriber('/joint_states', JointState, self.joint_state_callback)
         self.img_sub = rospy.Subscriber('image_raw_nozoom', Image, self.image_callback)
         self.img_pub = rospy.Publisher('image_raw', Image, queue_size=1)
-        self.state_pub = rospy.Publisher('ptz_state', PtzPosition, queue_size=1)
+        self.state_pub = rospy.Publisher('ptz_state', PtzState, queue_size=1)
 
         self.pan_cmd = rospy.Publisher('/pan_position_controller/command', Float64, queue_size=1)
         self.tilt_cmd = rospy.Publisher('/tilt_position_controller/command', Float64, queue_size=1)
 
-        self.ptz_srv = actionlib.SimpleActionServer('move_ptz', PtzAction, self.ptz_actionHandler, False)
+        self.ptz_srv = actionlib.SimpleActionServer('position', PtzAction, self.ptz_actionHandler, False)
         self.ptz_srv.start()
 
         # spin and publish the ptz status at 10Hz
         rate = rospy.Rate(10)
         while not rospy.is_shutdown():
-            psn = PtzPosition()
+            psn = PtzState()
             psn.pan = self.current_pan
             psn.tilt = self.current_tilt
             psn.zoom = self.current_zoom
+            if self.is_moving or self.is_zooming:
+                psn.mode = PtzState.MODE_POSITION
+            else:
+                psn.mode = PtzState.MODE_IDLE
+
             self.state_pub.publish(psn)
 
             rate.sleep()


### PR DESCRIPTION
# Dependency Notice
Depends on https://github.com/ros-drivers/axis_camera/pull/80 for changes to the `axis_camera` driver

# Changes
Adds several new features:
- overhauled Axis PTZ action server support for the new driver
- support for velocity & position control
- ability to point the camera parallel to any frame in the TF tree (e.g. point the camera relative to the `map` frame's X axis for absolute cardinal directions)
- ability to point the camera _at_ any frame in the TF tree
- ability to move the camera relative to its current pan/tilt
- Use +pan = clockwise, +tilt = up consistently (previously +pan was counterclockwise, but this made cardinal direction support messy, so it's been inverted)
- Simulated PTZ camera action server supports absolute, relative, and TF-based position control. Velocity control is not supported.
- Use 1x to Nx values for zoom level instead of percentages consistently
- Rename action server nodes to use consistent node names in distinct namespaces to make it easier to automate external parameter loading (e.g. reading pan/tilt/zoom limits for rendering a GUI)

# To-Do
- Flir PTU action server has not yet been tested
- Flir PTU action server does not support TF-based position control yet